### PR TITLE
Improving empty form

### DIFF
--- a/src/components/EditTodoForm.tsx
+++ b/src/components/EditTodoForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { Button, FormControl, HStack, Input, Text } from '@chakra-ui/react';
 
 // propsの型を定義
@@ -11,6 +11,8 @@ type EditTodoFormProps = {
 export const EditTodoForm = ({ id, task, editTask }: EditTodoFormProps) => {
   // formの内容を保持するstate
   const [value, setValue] = useState<string>(task);
+  // formを参照するrefを作成
+  const inputRef = useRef<HTMLInputElement>(null);
 
   // formのsubmit時の処理
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {

--- a/src/components/EditTodoForm.tsx
+++ b/src/components/EditTodoForm.tsx
@@ -32,6 +32,7 @@ export const EditTodoForm = ({ id, task, editTask }: EditTodoFormProps) => {
       <FormControl mt="1rem" mb="2rem">
         <HStack>
           <Input
+            ref={inputRef}
             type="text"
             placeholder="What is the task today?"
             value={value}

--- a/src/components/EditTodoForm.tsx
+++ b/src/components/EditTodoForm.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Button, FormControl, HStack, Input, Text } from '@chakra-ui/react';
 
 // propsの型を定義
@@ -13,6 +13,14 @@ export const EditTodoForm = ({ id, task, editTask }: EditTodoFormProps) => {
   const [value, setValue] = useState<string>(task);
   // formを参照するrefを作成
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // formが表示された時にinputにフォーカスする
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, []);
 
   // formのsubmit時の処理
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {

--- a/src/components/EditTodoForm.tsx
+++ b/src/components/EditTodoForm.tsx
@@ -16,7 +16,10 @@ export const EditTodoForm = ({ id, task, editTask }: EditTodoFormProps) => {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     // idがidのtodoに対して、formの内容(value)でtaskの内容を更新してformの内容を空にする
-    if (!value) return;
+    if (!value) {
+      setValue(task);
+      return;
+    }
     editTask(id, value);
     setValue('');
     // console.log(value);


### PR DESCRIPTION
Todo編集時に、空のタスクで更新しようとした際の挙動を改良
（改良前）
ただ単に、空のタスクのままアップデートできない

（改良後）
編集前のタスクがフォーム内に全選択の状態で表示される
